### PR TITLE
add norid to the list

### DIFF
--- a/domains.json
+++ b/domains.json
@@ -98,5 +98,6 @@
   "rema.no",
   "meny.no",
   "vipps.no",
-  "kode24.no"
+  "kode24.no",
+  "norid.no"
 ]


### PR DESCRIPTION
Norid is responsible for the .no domain, so I feel like they should be on the list.