### PR TITLE
adding transponder.no

### DIFF
--- a/domains.txt
+++ b/domains.txt
@@ -117,3 +117,4 @@ morrowbank.no
 spleis.no
 hyre.no
 nextgentel.no
+transponder.no


### PR DESCRIPTION
Transponder er brukt av noen skoler/kommuner for å kommunisere med foreldre/ansatter. 
Brukere må logge inn med BankID.
DMARC policy er ikke sett så vidt jeg kan se.